### PR TITLE
Add CLS config file.

### DIFF
--- a/SHED/Patches/MMrektCLS.cfg
+++ b/SHED/Patches/MMrektCLS.cfg
@@ -21,7 +21,8 @@
 	{
 		name = ModuleConnectedLivingSpace
 		passable = true
-		surfaceAttachmentsPassable = true
+		passablenodes = door3,door2,door1,top,bottom
+		surfaceAttachmentsPassable = false
 	}
 }
 

--- a/SHED/Patches/MMrektCLS.cfg
+++ b/SHED/Patches/MMrektCLS.cfg
@@ -1,0 +1,39 @@
+
+// Pods are only attachable via the door.
+
+@PART[rektmk1a,rektmk1d,rektmk1n]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		surfaceAttachmentsPassable = false
+		passablenodes = door
+		impassablenodes = top,bottom
+	}
+}
+
+// The triple adaptor is just a hallway - passable no matter what.
+
+@PART[inlineTripAdpt]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		surfaceAttachmentsPassable = true
+	}
+}
+
+// Decoupuler is passable no matter how it's attached - but be careful how you attach to it!
+
+@PART[shrekt]:HAS[!MODULE[ModuleConnectedLivingSpace]]:NEEDS[ConnectedLivingSpace]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+		surfaceAttachmentsPassable = false
+		passableWhenSurfaceAttached = true
+	}
+}


### PR DESCRIPTION
Add CLS config file.  All enterable pods can only be entered by the door, the 3-pod frame can be passed in any fashion, and the decoupler can be passed by it's nodes or if _it_ is surface attached.  (Not if you are surface attached to it.)
