### PR TITLE
solve cryopod power issue

### DIFF
--- a/SHED/Parts/REKT-mk1C/rektmk1c.cfg
+++ b/SHED/Parts/REKT-mk1C/rektmk1c.cfg
@@ -61,7 +61,7 @@ PART
 	RESOURCE
 	{
 		name = ElectricCharge
-		amount = 3000
+		amount = 50
 		maxAmount = 50
 	}
 	
@@ -112,6 +112,32 @@ PART
 		}
 	}
 
+	RESOURCE
+	{
+		name = SolidFuel
+		amount = 30
+		maxAmount = 30
+	}
+	MODULE
+	{
+		name = ModuleResourceConverter
+		ConverterName = Emergency Power Cell
+		StartActionName = Activate Power Cell
+		StopActionName = Deactivate Power Cell
+		
+		INPUT_RESOURCE {
+			ResourceName = SolidFuel
+			Ratio = 30
+			FlowMode = NO_FLOW
+		}
+		OUTPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 3000
+			FlowMode = NO_FLOW
+			DumpExcess = false
+		}
+	}
 
 	MODULE
 	{


### PR DESCRIPTION
A converter (solid fuel power cell) supplying instantaneous 3000EC works without needing a buffer.